### PR TITLE
fix: add width and height for ios devices in onCanvasResize

### DIFF
--- a/src/lib/Chart.tsx
+++ b/src/lib/Chart.tsx
@@ -71,6 +71,7 @@ interface ChartProps {
 
     onHover?: (x: number, event: PointerEvent) => void;
     onHoverEnd?: () => void;
+    onTouchUp?: (x: number, event: PointerEvent) => void;
 }
 
 function arrayMergeOverwrite<T>(_: T[], sourceArray: T[]): T[] {
@@ -119,7 +120,7 @@ export interface ChartRef {
 }
 
 export const Chart = forwardRef<ChartRef, ChartProps>((props, ref) => {
-    const { onHover, onHoverEnd } = props;
+    const { onHover, onHoverEnd, onTouchUp } = props;
 
     const worker = useWorker();
 
@@ -230,6 +231,7 @@ export const Chart = forwardRef<ChartRef, ChartProps>((props, ref) => {
                 }}
                 onHover={onHover}
                 onHoverEnd={onHoverEnd}
+                onTouchUp={onTouchUp}
             />
             <ChartContext.Provider value={chartContextValue}>{props.children}</ChartContext.Provider>
 

--- a/src/lib/Chart.tsx
+++ b/src/lib/Chart.tsx
@@ -92,7 +92,12 @@ function useCanvas(onResize: (sizeCpx: Size) => void) {
     const onCanvasResize = useCallback(
         function onCanvasResize(entries: ResizeObserverEntry[]) {
             if (canvas == null) return;
-            const { inlineSize: width, blockSize: height } = entries[0].devicePixelContentBoxSize[0];
+            const width =
+                entries[0]?.devicePixelContentBoxSize?.[0].inlineSize ??
+                entries[0].contentBoxSize[0].inlineSize * 2;
+            const height =
+                entries[0]?.devicePixelContentBoxSize?.[0].blockSize ??
+                entries[0].contentBoxSize[0].blockSize * 2;
             setCanvasSizeCpx({ width, height });
             onResize({ width, height });
         },

--- a/src/lib/Chart.tsx
+++ b/src/lib/Chart.tsx
@@ -93,12 +93,10 @@ function useCanvas(onResize: (sizeCpx: Size) => void) {
     const onCanvasResize = useCallback(
         function onCanvasResize(entries: ResizeObserverEntry[]) {
             if (canvas == null) return;
-            const width =
-                entries[0]?.devicePixelContentBoxSize?.[0].inlineSize ??
-                entries[0].contentBoxSize[0].inlineSize * 2;
-            const height =
-                entries[0]?.devicePixelContentBoxSize?.[0].blockSize ??
-                entries[0].contentBoxSize[0].blockSize * 2;
+
+            const dpr = window.devicePixelRatio;
+            const width = entries[0].contentBoxSize[0].inlineSize * dpr;
+            const height = entries[0].contentBoxSize[0].blockSize * dpr;
             setCanvasSizeCpx({ width, height });
             onResize({ width, height });
         },

--- a/src/lib/Manipulator.tsx
+++ b/src/lib/Manipulator.tsx
@@ -6,15 +6,16 @@ interface ManipulatorProps {
     style: CSSProperties;
     onHover?: (x: number, event: PointerEvent) => void;
     onHoverEnd?: () => void;
+    onTouchUp?: (x: number, event: PointerEvent) => void;
 }
 
 export function Manipulator(props: ManipulatorProps) {
-    const { onHover, onHoverEnd } = props;
+    const { onHover, onHoverEnd, onTouchUp } = props;
     const { xBoundsLimit, settledXBounds, onManipulation, onManipulationEnd } = useBoundsContext();
 
     const [glass, setGlass] = useState<HTMLDivElement | null>(null);
 
-    useDragAndZoom(glass, settledXBounds, onManipulation, onManipulationEnd, onHover, onHoverEnd, {
+    useDragAndZoom(glass, settledXBounds, onManipulation, onManipulationEnd, onHover, onHoverEnd, onTouchUp, {
         boundsLimit: xBoundsLimit,
     });
 
@@ -24,7 +25,7 @@ export function Manipulator(props: ManipulatorProps) {
             className="glass"
             style={{
                 position: "absolute",
-                touchAction: "none",
+                touchAction: "pan-x pan-y",
                 ...props.style,
             }}
         />

--- a/src/lib/useDragAndZoom.tsx
+++ b/src/lib/useDragAndZoom.tsx
@@ -73,6 +73,7 @@ export function useDragAndZoom(
     onEnd: (viewport: Bounds) => void,
     onHover?: (x: number, event: PointerEvent) => void,
     onHoverEnd?: () => void,
+    onTouchUp?: (x: number, event: PointerEvent) => void,
     options: DragAndZoomOptions = {},
 ): void {
     // FIXME: возможно можно избежать лишних rebind'ов если хранить viewport
@@ -84,6 +85,8 @@ export function useDragAndZoom(
 
         const touchInfo: SafeDictionary<TouchDetails, number | string> = {};
         let temporaryViewport: Bounds = viewport;
+
+        let startX, startY;
 
         function calcXInTemporaryViewport(pageX: number, bounds: DOMRect): number {
             return (
@@ -126,7 +129,9 @@ export function useDragAndZoom(
         };
 
         const onTouchStart = (event: TouchEvent) => {
-            event.preventDefault();
+            startX = event.touches[0].clientX;
+            startY = event.touches[0].clientY;
+
             if (Object.keys(touchInfo).length == 0) {
                 temporaryViewport = viewport;
             }
@@ -161,7 +166,14 @@ export function useDragAndZoom(
         };
 
         const onPointerUp = (event: PointerEvent) => {
-            if (event.pointerType != "mouse") return;
+            if (event.pointerType != "mouse") {
+                const bounds = element.getBoundingClientRect();
+                if (onTouchUp) {
+                    onTouchUp(calcXInTemporaryViewport(event.pageX, bounds), event);
+                }
+                return
+            }
+
             delete touchInfo[event.pointerId];
             if (Object.keys(touchInfo).length == 0) {
                 onEnd(temporaryViewport);
@@ -170,6 +182,14 @@ export function useDragAndZoom(
         };
 
         const onTouchMove = (event: TouchEvent) => {
+            const moveX = event.touches[0].clientX;
+            const moveY = event.touches[0].clientY;
+
+            const diffX = moveX - startX;
+            const diffY = moveY - startY;
+
+            if (Math.abs(diffX) < Math.abs(diffY) && event.changedTouches.length === 1) return;
+
             const bounds = element.getBoundingClientRect();
             iterateTouchList(event.changedTouches, (touch) => {
                 const info = touchInfo[touch.identifier];

--- a/src/lib/useDragAndZoom.tsx
+++ b/src/lib/useDragAndZoom.tsx
@@ -86,7 +86,7 @@ export function useDragAndZoom(
         const touchInfo: SafeDictionary<TouchDetails, number | string> = {};
         let temporaryViewport: Bounds = viewport;
 
-        let startX, startY;
+        let startX: number, startY: number;
 
         function calcXInTemporaryViewport(pageX: number, bounds: DOMRect): number {
             return (
@@ -168,9 +168,7 @@ export function useDragAndZoom(
         const onPointerUp = (event: PointerEvent) => {
             if (event.pointerType != "mouse") {
                 const bounds = element.getBoundingClientRect();
-                if (onTouchUp) {
-                    onTouchUp(calcXInTemporaryViewport(event.pageX, bounds), event);
-                }
+                onTouchUp?.(calcXInTemporaryViewport(event.pageX, bounds), event);
                 return
             }
 
@@ -188,7 +186,8 @@ export function useDragAndZoom(
             const diffX = moveX - startX;
             const diffY = moveY - startY;
 
-            if (Math.abs(diffX) < Math.abs(diffY) && event.changedTouches.length === 1) return;
+            if (Math.abs(diffX) < Math.abs(diffY) && event.touches.length === 1) return
+            event.preventDefault()
 
             const bounds = element.getBoundingClientRect();
             iterateTouchList(event.changedTouches, (touch) => {


### PR DESCRIPTION
Here’s a brief summary of the issues I addressed in the PR

1. Fixed incorrect chart rendering on iOS devices
2. Resolved scrolling issues on touch devices
3. Added touch end event for charts