### PR TITLE
add min_width = 1 in bottom_status & vertical_filling

### DIFF
--- a/src/lib/worker/drawers/drawBottomStatus.ts
+++ b/src/lib/worker/drawers/drawBottomStatus.ts
@@ -49,9 +49,10 @@ export function drawBottomStatus(
     for (const [x1, x2] of intervals) {
         const t1 = Math.round((x1 - xMin) * multiplier + drawX1);
         const t2 = Math.round((x2 - xMin) * multiplier + drawX1);
+        const width = Math.max(t2 - t1, 1);
 
         // FIXME: optimize this by skipping drawing if the filling is outside of the plot area
         // FIXME #2: maybe optimize this by using binary search to find the first interval that is inside the plot area
-        ctx.fillRect(t1, drawY, t2 - t1, drawHeight);
+        ctx.fillRect(t1, drawY, width, drawHeight);
     }
 }

--- a/src/lib/worker/drawers/drawVerticalFilling.ts
+++ b/src/lib/worker/drawers/drawVerticalFilling.ts
@@ -22,9 +22,10 @@ export function drawVerticalFilling(
     for (const [x1, x2] of intervals) {
         const t1 = Math.round((x1 - xMin) * gridWidthDivXBounds + plotAreaX);
         const t2 = Math.round((x2 - xMin) * gridWidthDivXBounds + plotAreaX);
+        const width = Math.max(t2 - t1, 1);
 
         // FIXME: optimize this by skipping drawing if the filling is outside of the plot area
         // FIXME #2: maybe optimize this by using binary search to find the first interval that is inside the plot area
-        ctx.fillRect(t1, plotAreaY, t2 - t1, plotAreaH);
+        ctx.fillRect(t1, plotAreaY, width, plotAreaH);
     }
 }


### PR DESCRIPTION
I noticed that at a large scroll, BottomStatus and VerticalFilling have a width of 0, so I decided to fix it.