### PR TITLE
feat: always show y bounds

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -20,7 +20,12 @@ const log10_5 = Math.log10(5);
 const log10_4 = Math.log10(4);
 const log10_2 = Math.log10(2);
 
-export function* generateTicks(range: Bounds, pixels: number, minPixels: number): Generator<number> {
+export function* generateTicks(
+    range: Bounds,
+    pixels: number,
+    minPixels: number,
+    startOrEndMinPixels?: number,
+): Generator<number> {
     const xRange = range[1] - range[0];
 
     const targetXStepLog = Math.log10((xRange / pixels) * minPixels);
@@ -40,7 +45,7 @@ export function* generateTicks(range: Bounds, pixels: number, minPixels: number)
     const xMin = Math.ceil((range[0] * epsilonMin) / xStep) * xStep * epsilonMin;
     const xMax = Math.floor((range[1] * epsilonMax) / xStep) * xStep * epsilonMax;
 
-    if (xMin - range[0] > xStep / 3) {
+    if (startOrEndMinPixels && xMin - range[0] > startOrEndMinPixels) {
         yield range[0];
     }
 
@@ -48,7 +53,7 @@ export function* generateTicks(range: Bounds, pixels: number, minPixels: number)
         yield x;
     }
 
-    if (range[1] - xMax > xStep / 3) {
+    if (startOrEndMinPixels && range[1] - xMax > startOrEndMinPixels) {
         yield range[1];
     }
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -40,8 +40,16 @@ export function* generateTicks(range: Bounds, pixels: number, minPixels: number)
     const xMin = Math.ceil((range[0] * epsilonMin) / xStep) * xStep * epsilonMin;
     const xMax = Math.floor((range[1] * epsilonMax) / xStep) * xStep * epsilonMax;
 
+    if (xMin - range[0] > xStep / 3) {
+        yield range[0];
+    }
+
     for (let x = xMin; x <= xMax; x += xStep) {
         yield x;
+    }
+
+    if (range[1] - xMax > xStep / 3) {
+        yield range[1];
     }
 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -24,7 +24,7 @@ export function* generateTicks(
     range: Bounds,
     pixels: number,
     minPixels: number,
-    startOrEndMinPixels?: number,
+    minLineHeight?: number,
 ): Generator<number> {
     const xRange = range[1] - range[0];
 
@@ -45,7 +45,7 @@ export function* generateTicks(
     const xMin = Math.ceil((range[0] * epsilonMin) / xStep) * xStep * epsilonMin;
     const xMax = Math.floor((range[1] * epsilonMax) / xStep) * xStep * epsilonMax;
 
-    if (startOrEndMinPixels && xMin - range[0] > startOrEndMinPixels) {
+    if (minLineHeight && xMin - range[0] > minLineHeight) {
         yield range[0];
     }
 
@@ -53,7 +53,7 @@ export function* generateTicks(
         yield x;
     }
 
-    if (startOrEndMinPixels && range[1] - xMax > startOrEndMinPixels) {
+    if (minLineHeight && range[1] - xMax > minLineHeight) {
         yield range[1];
     }
 }

--- a/src/lib/worker/drawers/drawYLegend.ts
+++ b/src/lib/worker/drawers/drawYLegend.ts
@@ -17,7 +17,12 @@ export function drawYLegend(drawContext: DrawContext, legendSettings: LegendSett
 
     const bulletRadiusDpr = legendSettings.bulletRadius * dpr;
 
-    for (const y of generateTicks(yBounds, drawArea.height, legendSettings.y.minHeight)) {
+    for (const y of generateTicks(
+        yBounds,
+        drawArea.height,
+        legendSettings.y.minHeight,
+        legendSettings.labels.fontSize,
+    )) {
         const ypx = Math.round(scale(y, yBounds, [drawArea.y + drawArea.height, drawArea.y]));
         ctx.beginPath();
         ctx.ellipse(drawArea.x, ypx, bulletRadiusDpr, bulletRadiusDpr, 0, 0, 2 * Math.PI);


### PR DESCRIPTION
Hi, the boundaries on the Y-axis are not always drawn. I fixed this, but I'm not sure about the solution 

```typescript
    if (xMin - range[0] > xStep / 3) {
        yield range[0];
    }
```

 
 We need to take some margin so that the values do not overlap. xStep / 3 performed well during testing with different values.


![image](https://github.com/user-attachments/assets/4bf0088a-d748-4680-88b3-a97590b140d2) ![image](https://github.com/user-attachments/assets/1c530eb7-8655-4561-b71a-910dd42cfb67) 





