### PR TITLE
Cleanup fallback implementation for browsers without OffscreenCanvas support

### DIFF
--- a/.idea/prettier.xml
+++ b/.idea/prettier.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="PrettierConfiguration">
+    <option name="myConfigurationMode" value="AUTOMATIC" />
     <option name="myRunOnSave" value="true" />
     <option name="myRunOnReformat" value="true" />
   </component>

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,6 +1,6 @@
 import type { Preview } from "@storybook/react";
 import { WorkerCreatorProvider } from "../src/lib";
-import { getCreateWorkerOrFallback } from "../src/stories/utils";
+import AnagraphChartWorker from "../src/stories/storybook-worker";
 
 const preview: Preview = {
     parameters: {
@@ -14,7 +14,7 @@ const preview: Preview = {
     },
     decorators: [
         (Story, context) => (
-            <WorkerCreatorProvider workerCreator={getCreateWorkerOrFallback()}>{Story()}</WorkerCreatorProvider>
+            <WorkerCreatorProvider workerCreator={() => new AnagraphChartWorker()}>{Story()}</WorkerCreatorProvider>
         ),
     ],
 };

--- a/src/lib/Chart.tsx
+++ b/src/lib/Chart.tsx
@@ -29,6 +29,7 @@ import { Bounds, divSize, Size } from "./basic-types";
 import { ChartSettings, defaultChartSettings } from "./settings-types";
 import { BottomStatus, Id, LineInfo, VerticalFilling } from "./worker/worker-types";
 import { calcManipulationAreaLpx } from "./layout-utils";
+import { createCanvasHandler } from "./worker";
 
 interface ChartContextType {
     addLine(id: Id, lineInfo: LineInfo): void;
@@ -80,9 +81,38 @@ function arrayMergeOverwrite<T>(_: T[], sourceArray: T[]): T[] {
     return sourceArray;
 }
 
-function useWorker() {
+interface CanvasWorkerSubset {
+    postMessage(msg: MainToWorkerMessage, transfer?: Transferable[]): void;
+    addEventListener(event: "message", handler: (msg: MessageEvent<WorkerToMainMessage>) => void): void;
+    removeEventListener(event: "message", handler: (msg: MessageEvent<WorkerToMainMessage>) => void): void;
+    terminate(): void;
+}
+
+function createFallbackPseudoWorker(): CanvasWorkerSubset {
+    console.log("Anagraph: Warning: OffscreenCanvas is not supported, using single-threaded drawing code");
+    const handler = createCanvasHandler((msg) => global.postMessage(msg));
+    handler.startSendingFps();
+    return {
+        postMessage(msg: MainToWorkerMessage, transfer?: Transferable[]) {
+            setTimeout(() => handler.handleMainToWorkerMessage(msg), 0);
+        },
+        addEventListener: global.addEventListener.bind(global),
+        removeEventListener: global.removeEventListener.bind(global),
+        terminate: () => {
+            handler.stopSendingFps();
+        },
+    };
+}
+function useWorker(): CanvasWorkerSubset {
+    const hasOffscreenSupport = HTMLCanvasElement.prototype.transferControlToOffscreen !== undefined;
     const workerCreator = useWorkerCreator();
-    const worker = useMemo(() => workerCreator(), []);
+    const worker = useMemo((): CanvasWorkerSubset => {
+        if (hasOffscreenSupport) {
+            return workerCreator();
+        } else {
+            return createFallbackPseudoWorker();
+        }
+    }, [hasOffscreenSupport]);
     useUnmount(() => worker.terminate());
     return worker;
 }

--- a/src/lib/WorkerCreatorContext.tsx
+++ b/src/lib/WorkerCreatorContext.tsx
@@ -13,7 +13,7 @@ const WorkerCreatorContext = createContext<WorkerCreatorContextType>({
 });
 
 interface WorkerCreatorProviderProps {
-    workerCreator: () => Worker;
+    workerCreator: WorkerCreator;
     children: ReactNode | ReactNode[];
 }
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,5 @@
 export { WorkerCreatorProvider } from "./WorkerCreatorContext";
-export { startWorker, createFallback } from "./worker";
+export { startWorker } from "./worker";
 export { Chart } from "./Chart";
 export type { ChartRef } from "./Chart";
 export { Line } from "./Line";

--- a/src/stories/utils.ts
+++ b/src/stories/utils.ts
@@ -1,16 +1,3 @@
-import AnagraphChartWorker from "./storybook-worker";
-import { createFallback } from "../lib/index";
-
 export function ts(year: number, month: number, day: number, hour: number = 0, minute: number = 0, second: number = 0) {
     return new Date(year, month, day, hour, minute, second).getTime();
-}
-
-export function getCreateWorkerOrFallback(): () => Worker {
-    const isSupport = HTMLCanvasElement.prototype.transferControlToOffscreen !== undefined;
-
-    if (!isSupport) {
-        return () => createFallback();
-    }
-
-    return () => new AnagraphChartWorker();
 }


### PR DESCRIPTION
- Check for `OffscreenCanvas` support moved from the user code to the inside of the library.
- `Chart` will check for `OffscreenCanvas` support and automatically use single-threaded pseudo-worker as a fallback.
- If `OffscreenCanvas` is supported, user-provided `workerCreator` will be used instead
- More clean implementation