### PR TITLE
feat: add disableWorker flag in Chart

### DIFF
--- a/src/stories/Chart.stories.tsx
+++ b/src/stories/Chart.stories.tsx
@@ -17,6 +17,8 @@ export const Simple: Story = {
             },
         },
 
+        disableWorker: false,
+
         style: {
             outline: "1px solid #ccc",
         },


### PR DESCRIPTION
Hi, I’ve added a new disableWorker flag that allows manually disabling the use of workers.

This was needed to simplify debugging and provide a quick way to bypass worker-related issues when necessary. When the flag is enabled, the logic runs without workers; otherwise, the existing behavior remains unchanged.

Let me know if anything should be adjusted