### PR TITLE
fix: tick precision and min/max edge tick rendering in generateTicks

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -39,13 +39,15 @@ export function* generateTicks(
     }
     const xStep = Math.pow(10, xStepLog);
 
-    const epsilonMin = range[0] > 0 ? 1 / 1.0001 : 1.0001;
-    const epsilonMax = range[1] > 0 ? 1.0001 : 1 / 1.0001;
+    const epsilonMin = range[0] > 0 ? 1 / 1.0000000001 : 1.0000000001;
+    const epsilonMax = range[1] > 0 ? 1.0000000001 : 1 / 1.0000000001;
 
     const xMin = Math.ceil((range[0] * epsilonMin) / xStep) * xStep * epsilonMin;
     const xMax = Math.floor((range[1] * epsilonMax) / xStep) * xStep * epsilonMax;
+    
+    const unitsPerPixel = xRange / pixels;
 
-    if (minLineHeight && xMin - range[0] > minLineHeight) {
+    if (minLineHeight && (xMin - range[0]) / unitsPerPixel > minLineHeight) {
         yield range[0];
     }
 
@@ -53,7 +55,7 @@ export function* generateTicks(
         yield x;
     }
 
-    if (minLineHeight && range[1] - xMax > minLineHeight) {
+    if (minLineHeight && (range[1] - xMax) / unitsPerPixel > minLineHeight) {
         yield range[1];
     }
 }


### PR DESCRIPTION
Hello, it was noticed that the Y-axis could render oddly when the tick step became large, due to floating-point precision artifacts. This PR fixes tick generation/normalization to remove values like ...999999 and make labels/grid lines stable.

It also improves min/max edge rendering: boundary tick inclusion now uses pixel-based distance checks, so edge ticks are drawn consistently and predictably.

<img width="360" height="385" alt="image" src="https://github.com/user-attachments/assets/5f853c58-790f-4dea-90b4-51a632a8109f" />
<img width="360" height="385" alt="image" src="https://github.com/user-attachments/assets/112b5fc8-2407-44a8-a578-d14a87ae1975" />
