### PR TITLE
ref: change yAxis draw logic

### DIFF
--- a/src/lib/settings-types.ts
+++ b/src/lib/settings-types.ts
@@ -27,7 +27,8 @@ export interface LegendSettings {
         draw: boolean;
         width: number;
         gap: number;
-        minHeight: 48;
+        minHeight: number;
+        edgeMinHeight: number;
     };
 }
 
@@ -71,6 +72,7 @@ export const defaultChartSettings: ChartSettings = {
             width: 60,
             gap: 8,
             minHeight: 48,
+            edgeMinHeight: 24,
         },
 
         bulletRadius: 2,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -24,7 +24,7 @@ export function* generateTicks(
     range: Bounds,
     pixels: number,
     minPixels: number,
-    minLineHeight?: number,
+    edgeMinHeight: number,
 ): Generator<number> {
     const xRange = range[1] - range[0];
 
@@ -44,18 +44,24 @@ export function* generateTicks(
 
     const xMin = Math.ceil((range[0] * epsilonMin) / xStep) * xStep * epsilonMin;
     const xMax = Math.floor((range[1] * epsilonMax) / xStep) * xStep * epsilonMax;
-    
+
     const unitsPerPixel = xRange / pixels;
 
-    if (minLineHeight && (xMin - range[0]) / unitsPerPixel > minLineHeight) {
-        yield range[0];
-    }
+    yield range[0];
 
     for (let x = xMin; x <= xMax; x += xStep) {
+        const isBoundaryDuplicate = Math.abs(x - range[0]) < xStep * 1e-9 || Math.abs(x - range[1]) < xStep * 1e-9;
+        const isTooCloseToMin = (x - range[0]) / unitsPerPixel < edgeMinHeight;
+        const isTooCloseToMax = (range[1] - x) / unitsPerPixel < edgeMinHeight;
+
+        if (isBoundaryDuplicate || isTooCloseToMin || isTooCloseToMax) {
+            continue;
+        }
+
         yield x;
     }
 
-    if (minLineHeight && (range[1] - xMax) / unitsPerPixel > minLineHeight) {
+    if (range[1] !== range[0]) {
         yield range[1];
     }
 }

--- a/src/lib/worker/drawers/drawChart.ts
+++ b/src/lib/worker/drawers/drawChart.ts
@@ -44,7 +44,14 @@ export function drawChart(drawContext: DrawContext, chartInfo: ChartInfo) {
         drawTimeXGrid(drawContext, settings.grid.lines, settings.legend.labels, xBounds, xGridArea);
     }
     if (settings.grid.y.draw) {
-        drawYGrid(drawContext, settings.legend.y.minHeight, settings.grid.lines, settings.grid.y.bounds, yGridArea);
+        drawYGrid(
+            drawContext,
+            settings.legend.y.minHeight,
+            settings.legend.y.edgeMinHeight,
+            settings.grid.lines,
+            settings.grid.y.bounds,
+            yGridArea,
+        );
     }
 
     if (settings.grid.outline.draw) {

--- a/src/lib/worker/drawers/drawYGrid.ts
+++ b/src/lib/worker/drawers/drawYGrid.ts
@@ -6,6 +6,7 @@ import { generateTicks, scale } from "../../utils";
 export function drawYGrid(
     drawContext: DrawContext,
     minYLegendHeight: number,
+    minYEdgeHeight: number,
     lineSettings: GridLineSettings,
     yBounds: Bounds,
     drawArea: Rect,
@@ -18,7 +19,7 @@ export function drawYGrid(
     ctx.strokeStyle = color;
     ctx.lineWidth = lineWidth;
 
-    for (const y of generateTicks(yBounds, drawArea.height, minYLegendHeight)) {
+    for (const y of generateTicks(yBounds, drawArea.height, minYLegendHeight, minYEdgeHeight)) {
         const ypx = Math.round(scale(y, yBounds, [drawArea.y + drawArea.height, drawArea.y])) + 0.5;
         ctx.beginPath();
         ctx.moveTo(drawArea.x, ypx);

--- a/src/lib/worker/drawers/drawYLegend.ts
+++ b/src/lib/worker/drawers/drawYLegend.ts
@@ -21,7 +21,7 @@ export function drawYLegend(drawContext: DrawContext, legendSettings: LegendSett
         yBounds,
         drawArea.height,
         legendSettings.y.minHeight,
-        legendSettings.labels.fontSize,
+        legendSettings.y.edgeMinHeight,
     )) {
         const ypx = Math.round(scale(y, yBounds, [drawArea.y + drawArea.height, drawArea.y]));
         ctx.beginPath();


### PR DESCRIPTION
Hi! In this PR, I updated Y-axis tick generation and synchronized the behavior of the legend and the grid. The min and max Y values are now always included in the tick list, while ticks that end up too close to the boundaries are filtered out.

I also made the grid and the Y-axis legend use the same tick generation logic, so we should no longer see cases where a grid line is drawn without a matching label. To support this, I added a separate legend.y.edgeMinHeight setting to control the minimum distance between boundary values and neighboring ticks, while keeping legend.y.minHeight responsible for the density of inner ticks.

before
<img width="176" height="222" alt="Снимок экрана — 2026-05-04 в 14 11 38" src="https://github.com/user-attachments/assets/4ad3ef20-253e-4778-b692-4fff8d091a58" />
after
<img width="189" height="221" alt="Снимок экрана — 2026-05-04 в 14 11 04" src="https://github.com/user-attachments/assets/6e9ca2c1-06f5-4d37-b0ae-71235e018f75" />
